### PR TITLE
removing enhanced img

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
 		"@cloudflare/workers-types": "^4.20250313.0",
 		"@internationalized/date": "^3.7.0",
 		"@sveltejs/adapter-cloudflare": "^4.9.0",
-		"@sveltejs/enhanced-img": "^0.3.10",
 		"@sveltejs/kit": "^2.19.0",
 		"@sveltejs/vite-plugin-svelte": "^4.0.4",
 		"@tailwindcss/typography": "^0.5.16",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,9 +20,6 @@ importers:
       '@sveltejs/adapter-cloudflare':
         specifier: ^4.9.0
         version: 4.9.0(@sveltejs/kit@2.19.0(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.23.0)(vite@5.4.14(@types/node@22.10.2)))(svelte@5.23.0)(vite@5.4.14(@types/node@22.10.2)))(wrangler@3.114.1(@cloudflare/workers-types@4.20250313.0))
-      '@sveltejs/enhanced-img':
-        specifier: ^0.3.10
-        version: 0.3.10(rollup@4.35.0)(svelte@5.23.0)(vite@5.4.14(@types/node@22.10.2))
       '@sveltejs/kit':
         specifier: ^2.19.0
         version: 2.19.0(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.23.0)(vite@5.4.14(@types/node@22.10.2)))(svelte@5.23.0)(vite@5.4.14(@types/node@22.10.2))
@@ -806,15 +803,6 @@ packages:
   '@polka/url@1.0.0-next.28':
     resolution: {integrity: sha512-8LduaNlMZGwdZ6qWrKlfa+2M4gahzFkprZiAt2TF8uS0qQgBizKXpXURqvTJ4WtmupWxaLqjRb2UCTe72mu+Aw==}
 
-  '@rollup/pluginutils@5.1.4':
-    resolution: {integrity: sha512-USm05zrsFxYLPdWWq+K3STlWiT/3ELn3RcV5hJMghpeAIhxfsUIg6mt12CBJBInWMV4VneoV7SfGv8xIwo2qNQ==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
-    peerDependenciesMeta:
-      rollup:
-        optional: true
-
   '@rollup/rollup-android-arm-eabi@4.35.0':
     resolution: {integrity: sha512-uYQ2WfPaqz5QtVgMxfN6NpLD+no0MYHDBywl7itPYd3K5TjjSghNKmX8ic9S8NU8w81NVhJv/XojcHptRly7qQ==}
     cpu: [arm]
@@ -941,12 +929,6 @@ packages:
     peerDependencies:
       '@sveltejs/kit': ^2.0.0
       wrangler: ^3.28.4
-
-  '@sveltejs/enhanced-img@0.3.10':
-    resolution: {integrity: sha512-1JxjthN6yb1md3rSFbHRDBi/Jj2R9EjE06vh9zbWgYxm5d4UUphTzNICJTis8bkIDQilbAokrkaQtfRpKSE7qg==}
-    peerDependencies:
-      svelte: ^4.0.0 || ^5.0.0-next.0
-      vite: '>= 5.0.0'
 
   '@sveltejs/kit@2.19.0':
     resolution: {integrity: sha512-UTx28Ad4sYsLU//gqkEo5aFOPFBRT2uXCmXTsURqhurDCvzkVwXruJgBcHDaMiK6RKKpYRteDUaXYqZyGPgCXQ==}
@@ -1392,9 +1374,6 @@ packages:
   estree-walker@0.6.1:
     resolution: {integrity: sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==}
 
-  estree-walker@2.0.2:
-    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
-
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -1516,10 +1495,6 @@ packages:
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
-
-  imagetools-core@7.0.2:
-    resolution: {integrity: sha512-nrLdKLJHHXd8MitwlXK6/h1TSwGaH3X1DZ3z6yMv/tX7dJ12ecLxZ6P5jgKetfIFh8IJwH9fCWMoTA8ixg0VVA==}
-    engines: {node: '>=18.0.0'}
 
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
@@ -2129,11 +2104,6 @@ packages:
       svelte:
         optional: true
 
-  svelte-parse-markup@0.1.5:
-    resolution: {integrity: sha512-T6mqZrySltPCDwfKXWQ6zehipVLk4GWfH1zCMGgRtLlOIFPuw58ZxVYxVvotMJgJaurKi1i14viB2GIRKXeJTQ==}
-    peerDependencies:
-      svelte: ^3.0.0 || ^4.0.0 || ^5.0.0-next.1
-
   svelte@5.23.0:
     resolution: {integrity: sha512-v0lL3NuKontiCxholEiAXCB+BYbndlKbwlDMK0DS86WgGELMJSpyqCSbJeMEMBDwOglnS7Ar2Rq0wwa/z2L8Vg==}
     engines: {node: '>=18'}
@@ -2240,10 +2210,6 @@ packages:
 
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
-
-  vite-imagetools@7.0.5:
-    resolution: {integrity: sha512-OOvVnaBTqJJ2J7X1cM1qpH4pj9jsfTxia1VSuWeyXtf+OnP8d0YI1LHpv8y2NT47wg+n7XiTgh3BvcSffuBWrw==}
-    engines: {node: '>=18.0.0'}
 
   vite@5.4.14:
     resolution: {integrity: sha512-EK5cY7Q1D8JNhSaPKVK4pwBFvaTmZxEnoKXLG/U9gmdDcihQGNzFlgIvaxezFR4glP1LsuiedwMBqCXH3wZccA==}
@@ -2808,14 +2774,6 @@ snapshots:
 
   '@polka/url@1.0.0-next.28': {}
 
-  '@rollup/pluginutils@5.1.4(rollup@4.35.0)':
-    dependencies:
-      '@types/estree': 1.0.6
-      estree-walker: 2.0.2
-      picomatch: 4.0.2
-    optionalDependencies:
-      rollup: 4.35.0
-
   '@rollup/rollup-android-arm-eabi@4.35.0':
     optional: true
 
@@ -2919,16 +2877,6 @@ snapshots:
       esbuild: 0.24.2
       worktop: 0.8.0-next.18
       wrangler: 3.114.1(@cloudflare/workers-types@4.20250313.0)
-
-  '@sveltejs/enhanced-img@0.3.10(rollup@4.35.0)(svelte@5.23.0)(vite@5.4.14(@types/node@22.10.2))':
-    dependencies:
-      magic-string: 0.30.17
-      svelte: 5.23.0
-      svelte-parse-markup: 0.1.5(svelte@5.23.0)
-      vite: 5.4.14(@types/node@22.10.2)
-      vite-imagetools: 7.0.5(rollup@4.35.0)
-    transitivePeerDependencies:
-      - rollup
 
   '@sveltejs/kit@2.19.0(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.23.0)(vite@5.4.14(@types/node@22.10.2)))(svelte@5.23.0)(vite@5.4.14(@types/node@22.10.2))':
     dependencies:
@@ -3215,11 +3163,13 @@ snapshots:
     dependencies:
       color-name: 1.1.4
       simple-swizzle: 0.2.2
+    optional: true
 
   color@4.2.3:
     dependencies:
       color-convert: 2.0.1
       color-string: 1.9.1
+    optional: true
 
   comma-separated-tokens@2.0.3: {}
 
@@ -3267,7 +3217,8 @@ snapshots:
 
   dequal@2.0.3: {}
 
-  detect-libc@2.0.3: {}
+  detect-libc@2.0.3:
+    optional: true
 
   devalue@5.1.1: {}
 
@@ -3486,8 +3437,6 @@ snapshots:
 
   estree-walker@0.6.1: {}
 
-  estree-walker@2.0.2: {}
-
   esutils@2.0.3: {}
 
   exit-hook@2.2.1: {}
@@ -3608,8 +3557,6 @@ snapshots:
 
   ignore@5.3.2: {}
 
-  imagetools-core@7.0.2: {}
-
   import-fresh@3.3.1:
     dependencies:
       parent-module: 1.0.1
@@ -3619,7 +3566,8 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
-  is-arrayish@0.3.2: {}
+  is-arrayish@0.3.2:
+    optional: true
 
   is-binary-path@2.1.0:
     dependencies:
@@ -3859,7 +3807,8 @@ snapshots:
 
   picomatch@2.3.1: {}
 
-  picomatch@4.0.2: {}
+  picomatch@4.0.2:
+    optional: true
 
   pify@2.3.0: {}
 
@@ -4058,6 +4007,7 @@ snapshots:
       '@img/sharp-wasm32': 0.33.5
       '@img/sharp-win32-ia32': 0.33.5
       '@img/sharp-win32-x64': 0.33.5
+    optional: true
 
   shebang-command@2.0.0:
     dependencies:
@@ -4081,6 +4031,7 @@ snapshots:
   simple-swizzle@0.2.2:
     dependencies:
       is-arrayish: 0.3.2
+    optional: true
 
   sirv@3.0.1:
     dependencies:
@@ -4166,10 +4117,6 @@ snapshots:
       postcss: 8.5.3
       postcss-scss: 4.0.9(postcss@8.5.3)
     optionalDependencies:
-      svelte: 5.23.0
-
-  svelte-parse-markup@0.1.5(svelte@5.23.0):
-    dependencies:
       svelte: 5.23.0
 
   svelte@5.23.0:
@@ -4326,14 +4273,6 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
       vfile-message: 4.0.2
-
-  vite-imagetools@7.0.5(rollup@4.35.0):
-    dependencies:
-      '@rollup/pluginutils': 5.1.4(rollup@4.35.0)
-      imagetools-core: 7.0.2
-      sharp: 0.33.5
-    transitivePeerDependencies:
-      - rollup
 
   vite@5.4.14(@types/node@22.10.2):
     dependencies:

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -25,7 +25,7 @@ import { visit } from "unist-util-visit";
  * @import {Root} from 'hast'
  */
 
-export function rehypeEnhancedImage() {
+export function rehypeUpdateImage() {
 	/**
 	 * @param {Root} tree
 	 * @return {undefined}
@@ -34,16 +34,7 @@ export function rehypeEnhancedImage() {
 		visit(tree, "element", (node) => {
 			// Check if the node is an img element
 			if (node.tagName === "img") {
-				if (typeof node.properties.src === "string") {
-					const srcext = node.properties.src?.toString().split(".").pop();
-
-					if (srcext === "gif") {
-						node.properties.src = node.properties.src.replace("/static", "");
-					} else {
-						// Change the tag name to 'enhanced:img'
-						node.tagName = "enhanced:img";
-					}
-				}
+				node.properties.src = node.properties.src.replace("/static", "");
 			}
 		});
 	};
@@ -51,7 +42,7 @@ export function rehypeEnhancedImage() {
 
 /** @type {import('mdsvex').MdsvexOptions} */
 const mdsvexOptions = {
-	rehypePlugins: [rehypeEnhancedImage],
+	rehypePlugins: [rehypeUpdateImage],
 	extensions: [".svx", ".md"],
 	highlight: {
 		highlighter: async (code, lang = "text") => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,6 @@
-import { enhancedImages } from "@sveltejs/enhanced-img";
 import { sveltekit } from "@sveltejs/kit/vite";
 import { defineConfig } from "vite";
 
 export default defineConfig({
-	plugins: [enhancedImages(), sveltekit()],
+	plugins: [sveltekit()],
 });


### PR DESCRIPTION
Giving up on using `@sveltejs/enhanced-img`, results in buggy behavior where refreshing the page results in lower resolution image than if it was through normal navigation. Building locally and deploying works as expected, however, in github actions and cloudflare deployment it doesn't. 